### PR TITLE
Fix test configuration

### DIFF
--- a/tests/TodoApp.Tests/TodoAppFixture.cs
+++ b/tests/TodoApp.Tests/TodoAppFixture.cs
@@ -59,8 +59,6 @@ namespace TodoApp
                 string? directory = Path.GetDirectoryName(typeof(HttpServerFixture).Assembly.Location);
                 string fullPath = Path.Combine(directory ?? ".", "testsettings.json");
 
-                builder.Sources.Clear();
-
                 builder.AddJsonFile(fullPath)
                        .AddInMemoryCollection(config);
             });

--- a/tests/TodoApp.Tests/testsettings.json
+++ b/tests/TodoApp.Tests/testsettings.json
@@ -1,6 +1,7 @@
 {
   "GitHub": {
     "ClientId": "github-id",
-    "ClientSecret": "github-secret"
+    "ClientSecret": "github-secret",
+    "EnterpriseDomain": ""
   }
 }


### PR DESCRIPTION
Fix configuration by not clearing sources, which was causing `UseUrls()` and any other changes made to the host being lost.

Explicitly set `EnterpriseDomain` to empty so my local secrets.json changes don't overwrite in in the tests without having to try and inspect the sources and manually remove user secrets.
