### PR TITLE
Refactor OpenAPI extensions

### DIFF
--- a/src/TodoApp/ApiModule.cs
+++ b/src/TodoApp/ApiModule.cs
@@ -92,7 +92,7 @@ public static class ApiModule
 
         // Redirect to Open API/Swagger documentation
         builder.MapGet("/api", () => Results.Redirect("/swagger-ui/index.html"))
-               .ExcludeFromApiExplorer()
+               .SuppressApi()
                .RequireAuthorization();
 
         return builder;

--- a/src/TodoApp/ApiModule.cs
+++ b/src/TodoApp/ApiModule.cs
@@ -92,8 +92,8 @@ public static class ApiModule
 
         // Redirect to Open API/Swagger documentation
         builder.MapGet("/api", () => Results.Redirect("/swagger-ui/index.html"))
-               .SuppressApi()
-               .RequireAuthorization();
+               .RequireAuthorization()
+               .SuppressApi();
 
         return builder;
     }

--- a/src/TodoApp/AuthenticationModule.cs
+++ b/src/TodoApp/AuthenticationModule.cs
@@ -63,23 +63,23 @@ public static class AuthenticationModule
     public static IEndpointRouteBuilder MapAuthenticationRoutes(this IEndpointRouteBuilder builder)
     {
         builder.MapGet(DeniedPath, () => Results.Redirect(RootPath + "?denied=true"))
-               .ExcludeFromApiExplorer();
+               .SuppressApi();
 
         builder.MapGet(SignOutPath, () => Results.Redirect(RootPath))
-               .ExcludeFromApiExplorer();
+               .SuppressApi();
 
         builder.MapPost(SignInPath, () =>
             Results.Challenge(
                 new AuthenticationProperties { RedirectUri = RootPath },
                 new[] { GitHubAuthenticationDefaults.AuthenticationScheme }))
-            .ExcludeFromApiExplorer();
+            .SuppressApi();
 
         builder.MapPost(SignOutPath, () =>
             Results.SignOut(
                 new AuthenticationProperties { RedirectUri = RootPath },
                 new[] { CookieAuthenticationDefaults.AuthenticationScheme }))
-            .ExcludeFromApiExplorer()
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .SuppressApi();
 
         return builder;
     }


### PR DESCRIPTION
Refactor the extensions for OpenAPI metadata to match proposed future API that will be built-in to ASP.NET Core to do the same thing.
