### PR TITLE
Refactor WebApplicationFactory<T> Usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     HACK Workaround for issues building with file-scoped
     namespaces in Visual Studio 2022 17.0 Preview 2.
   -->
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.0-3.21373.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/TodoApp.Tests/HttpServerFixture.cs
+++ b/tests/TodoApp.Tests/HttpServerFixture.cs
@@ -106,8 +106,6 @@ public sealed class HttpServerFixture : TodoAppFixture
     private void EnsureServer()
     {
         // This forces WebApplicationFactory to bootstrap the server
-        using (CreateDefaultClient())
-        {
-        }
+        using var _ = CreateDefaultClient();
     }
 }

--- a/tests/TodoApp.Tests/TodoAppFixture.cs
+++ b/tests/TodoApp.Tests/TodoAppFixture.cs
@@ -19,7 +19,6 @@ namespace TodoApp;
 public class TodoAppFixture : WebApplicationFactory<Services.ITodoService>, ITestOutputHelperAccessor
 {
     public TodoAppFixture()
-        : base()
     {
         // Use HTTPS by default and do not follow
         // redirects so they can tested explicitly.


### PR DESCRIPTION
Refactor the workaround for issue with `CreateHostBuilder()` returning `null` with minimal hosting by creating the server in `CreateHost()` instead.
