### PR TITLE
Only call CreateDefaultClient once

### DIFF
--- a/tests/TodoApp.Tests/HttpServerFixture.cs
+++ b/tests/TodoApp.Tests/HttpServerFixture.cs
@@ -105,7 +105,10 @@ public sealed class HttpServerFixture : TodoAppFixture
 
     private void EnsureServer()
     {
-        // This forces WebApplicationFactory to bootstrap the server
-        using var _ = CreateDefaultClient();
+        if (_host is null)
+        {
+            // This forces WebApplicationFactory to bootstrap the server
+            using var _ = CreateDefaultClient();
+        }
     }
 }


### PR DESCRIPTION
Only call `CreateDefaultClient()` if the host has not been created yet.
