### PR TITLE
Update SDK and OpenAPI extensions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21379.12",
+    "version": "6.0.100-rc.1.21403.71",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/TodoApp/ApiModule.cs
+++ b/src/TodoApp/ApiModule.cs
@@ -41,7 +41,7 @@ public static class ApiModule
                 var model = await service.GetAsync(user.GetUserId(), id, cancellationToken);
                 return model is null ? Results.Problem("Item not found.", statusCode: StatusCodes.Status404NotFound) : Results.Json(model);
             })
-            .Produces<TodoItemModel>()
+            .Produces<TodoItemModel>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization();
 
@@ -102,8 +102,8 @@ public static class ApiModule
 
         // Redirect to Open API/Swagger documentation
         builder.MapGet("/api", () => Results.Redirect("/swagger-ui/index.html"))
-               .RequireAuthorization()
-               .SuppressApi();
+               .ExcludeFromDescription()
+               .RequireAuthorization();
 
         return builder;
     }

--- a/src/TodoApp/AuthenticationModule.cs
+++ b/src/TodoApp/AuthenticationModule.cs
@@ -108,23 +108,17 @@ public static class AuthenticationModule
     public static IEndpointRouteBuilder MapAuthenticationRoutes(this IEndpointRouteBuilder builder)
     {
         builder.MapGet(DeniedPath, () => Results.Redirect(RootPath + "?denied=true"))
-               .SuppressApi();
+               .ExcludeFromDescription();
 
         builder.MapGet(SignOutPath, () => Results.Redirect(RootPath))
-               .SuppressApi();
+               .ExcludeFromDescription();
 
-        builder.MapPost(SignInPath, () =>
-            Results.Challenge(
-                new AuthenticationProperties { RedirectUri = RootPath },
-                new[] { GitHubAuthenticationDefaults.AuthenticationScheme }))
-            .SuppressApi();
+        builder.MapPost(SignInPath, () => Results.Challenge(new() { RedirectUri = RootPath }, new[] { GitHubAuthenticationDefaults.AuthenticationScheme }))
+               .ExcludeFromDescription();
 
-        builder.MapPost(SignOutPath, () =>
-            Results.SignOut(
-                new AuthenticationProperties { RedirectUri = RootPath },
-                new[] { CookieAuthenticationDefaults.AuthenticationScheme }))
-            .RequireAuthorization()
-            .SuppressApi();
+        builder.MapPost(SignOutPath, () => Results.SignOut(new() { RedirectUri = RootPath }, new[] { CookieAuthenticationDefaults.AuthenticationScheme }))
+               .ExcludeFromDescription()
+               .RequireAuthorization();
 
         return builder;
     }

--- a/src/TodoApp/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/TodoApp/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-    public static IEndpointConventionBuilder SuppressApi(this IEndpointConventionBuilder builder)
+    public static IEndpointConventionBuilder ExcludeFromDescription(this IEndpointConventionBuilder builder)
     {
         return builder.WithMetadata(_ignoreApiMetadata);
     }
@@ -37,13 +37,11 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// </summary>
     /// <typeparam name="TResponse">The type of the response.</typeparam>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
-    /// <param name="statusCode">The response status code. Defatuls to StatusCodes.Status200OK.</param>
-    /// <param name="contentType">The response content type. Defaults to "application/json"</param>
-    /// <param name="additionalContentTypes">Additional response content types the endpoint produces for the supplied status code.</param>
+    /// <param name="statusCode">The response status code.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
     public static IEndpointConventionBuilder Produces<TResponse>(
         this IEndpointConventionBuilder builder,
-        int statusCode = StatusCodes.Status200OK)
+        int statusCode)
     {
         return Produces(builder, statusCode, typeof(TResponse));
     }
@@ -52,12 +50,12 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// Adds metadata indicating the type of response an endpoint produces.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
-    /// <param name="statusCode">The response status code. Defaults to StatusCodes.Status200OK.</param>
+    /// <param name="statusCode">The response status code.</param>
     /// <param name="responseType">The type of the response. Defaults to null.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
     public static IEndpointConventionBuilder Produces(
         this IEndpointConventionBuilder builder,
-        int statusCode = StatusCodes.Status200OK,
+        int statusCode,
         Type? responseType = null)
     {
         return builder.WithMetadata(new ProducesResponseTypeAttribute(responseType ?? typeof(void), statusCode));
@@ -67,11 +65,11 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// Adds metadata indicating that the endpoint produces a Problem Details response.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
-    /// <param name="statusCode">The response status code. Defatuls to StatusCodes.Status500InternalServerError.</param>
+    /// <param name="statusCode">The response status code.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
     public static IEndpointConventionBuilder ProducesProblem(
         this IEndpointConventionBuilder builder,
-        int statusCode = StatusCodes.Status500InternalServerError)
+        int statusCode)
     {
         return Produces<ProblemDetails>(builder, statusCode);
     }

--- a/tests/TodoApp.Tests/UITests.cs
+++ b/tests/TodoApp.Tests/UITests.cs
@@ -68,6 +68,8 @@ public class UITests
             await items[0].DeleteAsync();
             await items[1].CompleteAsync();
 
+            await Task.Delay(TimeSpan.FromSeconds(0.5));
+
             // Assert
             items = await app.GetItemsAsync();
             items.Count.ShouldBe(1);


### PR DESCRIPTION
* Update to the latest .NET 6 RC1 SDK.
* Update the extension methods for OpenAPI metadata to match the latest proposed API for doing so.
* Wait half a second in test before checking the number of items to give the UI time to update.

