### PR TITLE
Run build on container creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
     "ms-vscode.PowerShell"
   ],
   "forwardPorts": [ 5001 ],
+  "postCreateCommand": "./build.ps1 -SkipTests",
   "remoteEnv": {
     "DOTNET_ROLL_FORWARD": "Major",
     "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnetcli:${containerEnv:PATH}"


### PR DESCRIPTION
Run build when the container is created to install the .NET SDK.
