### PR TITLE
Use universal Codespaces container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,7 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
-
-ARG VARIANT="5.0"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/universal:latest
 
 # Suppress an apt-key warning about standard out not being a terminal. Use in this script is safe.
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
-
-# Install Node.js
-RUN su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install lts/* 2>&1"
 
 # Install Google Chrome
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,16 @@
     "ms-vscode.PowerShell"
   ],
   "forwardPorts": [ 5000 ],
+  "portsAttributes":{
+    "5000": {
+      "label": "TodoApp",
+      "onAutoForward": "openBrowserOnce",
+      "protocol": "http"
+    },
+    "5001": {
+      "onAutoForward": "silent"
+    }
+  },
   "postCreateCommand": "./build.ps1 -SkipTests",
   "remoteEnv": {
     "DOTNET_ROLL_FORWARD": "Major",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,14 @@
 {
   "name": "C# (.NET)",
   "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      "VARIANT": "5.0"
-    }
+    "dockerfile": "Dockerfile"
   },
   "extensions": [
     "editorconfig.editorconfig",
     "ms-dotnettools.csharp",
     "ms-vscode.PowerShell"
   ],
-  "forwardPorts": [ 5001 ],
+  "forwardPorts": [ 5000 ],
   "postCreateCommand": "./build.ps1 -SkipTests",
   "remoteEnv": {
     "DOTNET_ROLL_FORWARD": "Major",

--- a/build.ps1
+++ b/build.ps1
@@ -83,7 +83,7 @@ function DotNetTest {
         throw "dotnet test failed with exit code $LASTEXITCODE"
     }
 
-    $nugetPath = Join-Path ($env:USERPROFILE ?? "~") ".nuget" "packages"
+    $nugetPath = $env:NUGET_PACKAGES ?? (Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages")
     $propsFile = Join-Path $solutionPath "tests" "TodoApp.Tests" "TodoApp.Tests.csproj"
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='ReportGenerator']/@Version").Node.'#text'
     $reportGeneratorPath = Join-Path $nugetPath "reportgenerator" $reportGeneratorVersion "tools" "net5.0" "ReportGenerator.dll"

--- a/build.ps1
+++ b/build.ps1
@@ -83,7 +83,7 @@ function DotNetTest {
         throw "dotnet test failed with exit code $LASTEXITCODE"
     }
 
-    $nugetPath = $env:NUGET_PACKAGES ?? (Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages")
+    $nugetPath = $env:NUGET_PACKAGES ?? (Join-Path ($env:USERPROFILE ?? "~") ".nuget" "packages")
     $propsFile = Join-Path $solutionPath "tests" "TodoApp.Tests" "TodoApp.Tests.csproj"
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='ReportGenerator']/@Version").Node.'#text'
     $reportGeneratorPath = Join-Path $nugetPath "reportgenerator" $reportGeneratorVersion "tools" "net5.0" "ReportGenerator.dll"

--- a/src/TodoApp/Pages/_ViewImports.cshtml
+++ b/src/TodoApp/Pages/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 @using TodoApp;
 @using TodoApp.Pages;
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -54,9 +54,12 @@ if (!app.Environment.IsDevelopment())
 
 app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
 
-// Require use of HTTPS
-app.UseHsts();
-app.UseHttpsRedirection();
+// Require use of HTTPS in production
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+    app.UseHttpsRedirection();
+}
 
 // Add static files for JavaScript, CSS and OpenAPI
 app.UseStaticFiles();


### PR DESCRIPTION
* Use the universal container for GitHub Codespaces.
* Use `NUGET_PACKAGES` for the NuGet global package cache if it is set.
* Launch port 5000 and ignore port 5001.
* Add tag helpers to the Razor Pages.
* Allow HTTP outside of production.
