### PR TITLE
Fixes for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,7 @@
     },
     "5001": {
       "label": "TodoApp",
-      "onAutoForward": "openBrowserOnce",
-      "protocol": "https"
+      "onAutoForward": "openBrowserOnce"
     }
   },
   "postCreateCommand": "./build.ps1 -SkipTests",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,15 +8,15 @@
     "ms-dotnettools.csharp",
     "ms-vscode.PowerShell"
   ],
-  "forwardPorts": [ 5000 ],
+  "forwardPorts": [ 5000, 5001 ],
   "portsAttributes":{
     "5000": {
-      "label": "TodoApp",
-      "onAutoForward": "openBrowserOnce",
-      "protocol": "http"
+      "onAutoForward": "silent"
     },
     "5001": {
-      "onAutoForward": "silent"
+      "label": "TodoApp",
+      "onAutoForward": "openBrowserOnce",
+      "protocol": "https"
     }
   },
   "postCreateCommand": "./build.ps1 -SkipTests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
       },
       "env": {
         "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "${env:CODESPACES}",
         "GitHub__ClientId": "${env:TODOAPP_GITHUB_CLIENTID}",
         "GitHub__ClientSecret": "${env:TODOAPP_GITHUB_CLIENTSECRET}"
       }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to [create a GitHub OAuth app] to obtain secrets for the `GitHub:ClientId` and
 `GitHub:ClientSecret` [options] so that the [OAuth user authentication] works and
 you can log into the Todo App UI.
 
-> 💡 When creating the GitHub OAuth app, use `https://localhost:5001/signin-github`
+> 💡 When creating the GitHub OAuth app, use `https://localhost:5001/sign-in-github`
 as the _Authorization callback URL_.
 
 > ⚠️ Do not commit GitHub OAuth secrets to source control. Configure them

--- a/src/TodoApp/AuthenticationModule.cs
+++ b/src/TodoApp/AuthenticationModule.cs
@@ -15,8 +15,8 @@ public static class AuthenticationModule
 {
     private const string DeniedPath = "/denied";
     private const string RootPath = "/";
-    private const string SignInPath = "/signin";
-    private const string SignOutPath = "/signout";
+    private const string SignInPath = "/sign-in";
+    private const string SignOutPath = "/sign-out";
 
     private const string GitHubAvatarClaim = "urn:github:avatar";
     private const string GitHubProfileClaim = "urn:github:profile";
@@ -43,6 +43,7 @@ public static class AuthenticationModule
             .Configure<IConfiguration>((options, configuration) =>
             {
                 options.AccessDeniedPath = DeniedPath;
+                options.CallbackPath = SignInPath + "-github";
                 options.ClientId = configuration["GitHub:ClientId"];
                 options.ClientSecret = configuration["GitHub:ClientSecret"];
                 options.EnterpriseDomain = configuration["GitHub:EnterpriseDomain"];

--- a/src/TodoApp/Pages/Home/Index.cshtml
+++ b/src/TodoApp/Pages/Home/Index.cshtml
@@ -12,7 +12,7 @@
     <p class="lead">
         Sign in with your GitHub account to manage your Todo list.
     </p>
-    <form action="~/signin" method="post">
+    <form action="~/sign-in" method="post">
         <button class="btn btn-lg btn-primary m-1" id="sign-in" type="submit">Sign in</button>
     </form>
 }

--- a/src/TodoApp/Pages/Shared/_Layout.cshtml
+++ b/src/TodoApp/Pages/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@
                 </ul>
                 @if (User.Identity!.IsAuthenticated)
                 {
-                    <form action="~/signout" method="post" class="navbar-right">
+                    <form action="~/sign-out" method="post" class="navbar-right">
                         <ul class="nav navbar-nav navbar-right">
                             <li>
                                 @{

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -50,24 +50,15 @@ builder.Services.AddSwaggerGen(options =>
     options.SwaggerDoc("v1", new() { Title = "Todo API", Version = "v1" });
 });
 
-// Configure the reverse proxy, if enabled, so OAuth works correctly
-bool forwardHeaders = string.Equals(
-    builder.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"],
-    "true",
-    StringComparison.OrdinalIgnoreCase);
-
-if (forwardHeaders)
+if (string.Equals(builder.Configuration["CODESPACES"], "true", StringComparison.OrdinalIgnoreCase))
 {
-    builder.Services.Configure<ForwardedHeadersOptions>(options => options.ForwardedHeaders = ForwardedHeaders.All);
+    // When running in GitHub Codespaces, X-Forwarded-Host also needs to be set
+    builder.Services.Configure<ForwardedHeadersOptions>(
+        options => options.ForwardedHeaders |= ForwardedHeaders.XForwardedHost);
 }
 
 // Create the app
 var app = builder.Build();
-
-if (forwardHeaders)
-{
-    app.UseForwardedHeaders();
-}
 
 // Configure error handling
 if (!app.Environment.IsDevelopment())

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -26,6 +26,12 @@ builder.Services.AddDbContext<TodoContext>((options) =>
         dataDirectory = Path.Combine(environment.ContentRootPath, "App_Data");
     }
 
+    // Ensure the configured data directory exists
+    if (!Directory.Exists(dataDirectory))
+    {
+        Directory.CreateDirectory(dataDirectory);
+    }
+
     var databaseFile = Path.Combine(dataDirectory, "TodoApp.db");
 
     options.UseSqlite("Data Source=" + databaseFile);

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using TodoApp;
@@ -43,8 +44,24 @@ builder.Services.AddSwaggerGen(options =>
     options.SwaggerDoc("v1", new() { Title = "Todo API", Version = "v1" });
 });
 
+// Configure the reverse proxy, if enabled, so OAuth works correctly
+bool forwardHeaders = string.Equals(
+    builder.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"],
+    "true",
+    StringComparison.OrdinalIgnoreCase);
+
+if (forwardHeaders)
+{
+    builder.Services.Configure<ForwardedHeadersOptions>(options => options.ForwardedHeaders = ForwardedHeaders.All);
+}
+
 // Create the app
 var app = builder.Build();
+
+if (forwardHeaders)
+{
+    app.UseForwardedHeaders();
+}
 
 // Configure error handling
 if (!app.Environment.IsDevelopment())

--- a/tests/TodoApp.Tests/ApiTests.cs
+++ b/tests/TodoApp.Tests/ApiTests.cs
@@ -261,7 +261,7 @@ public class ApiTests
 
         // Go through the sign-in flow, which will set
         // the authentication cookie on the HttpClient.
-        using var response = await client.PostAsync("/signin", content);
+        using var response = await client.PostAsync("/sign-in", content);
         response.IsSuccessStatusCode.ShouldBeTrue();
 
         return client;


### PR DESCRIPTION
* Change the path used to sign in as GitHub Codespaces seems to reserve `/signin`.
* Fix OAuth not working by configuring [nginx correctly for forwarded headers](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer#forward-the-scheme-for-linux-and-non-iis-reverse-proxies), including ensuring the `Host` is also forwarded so the redirect URI is correct.
* Configure port 5001 to be used by default.
