### PR TITLE
Disable NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "05:30"
-    timezone: Europe/London
-  reviewers:
-    - "martincostello"
-  open-pull-requests-limit: 99
+#- package-ecosystem: nuget
+#  directory: "/"
+#  schedule:
+#    interval: daily
+#    time: "05:30"
+#    timezone: Europe/London
+#  reviewers:
+#    - "martincostello"
+#  open-pull-requests-limit: 99
 - package-ecosystem: npm
   directory: "/src/TodoApp"
   schedule:


### PR DESCRIPTION
Disable NuGet package updates until the stable .NET 6 RC1 build is released.
