### PR TITLE
Update to .NET 6 RC1 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-#- package-ecosystem: nuget
-#  directory: "/"
-#  schedule:
-#    interval: daily
-#    time: "05:30"
-#    timezone: Europe/London
-#  reviewers:
-#    - "martincostello"
-#  open-pull-requests-limit: 99
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "05:30"
+    timezone: Europe/London
+  reviewers:
+    - "martincostello"
+  open-pull-requests-limit: 99
 - package-ecosystem: npm
   directory: "/src/TodoApp"
   schedule:

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,9 +1,8 @@
 name: update-dotnet-sdk
 
 on:
-  # TODO Re-enable once using a stable version of the SDK
-  #schedule:
-  #  - cron:  '0 * * * *'
+  schedule:
+    - cron:  '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <!-- TODO Remove feed above once RC1 is released -->
     <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
     <!-- TODO Remove feed above once .NET 6 is stable -->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 
 ## Introduction
 
-> ℹ️ This project currently depends on features in [daily builds] of the .NET
-`6.0.100-rc.1` SDK and requires preview builds of Visual Studio 2022 for IDE
-support.
+> ℹ️ This project currently depends on features in pre-releases of the .NET 6
+SDK and requires preview builds of Visual Studio 2022 for IDE support.
 >
 > To work with this sample directly from source with Visual Studio Code, run
 `build.ps1` and then `startvscode.cmd` or `startvscode.sh`.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21460.8",
+    "version": "6.0.100-rc.1.21458.32",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <!-- HACK Workaround for https://github.com/dotnet/sdk/issues/20444 -->
-    <LangVersion Condition="'$(BuildingInsideVisualStudio)' == 'true'">preview</LangVersion>
     <RootNamespace>TodoApp</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
@@ -10,7 +8,7 @@
     <UserSecretsId>TodoApp</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.0-preview.7.21426.32" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.0-rc.1.21464.72" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0-rc.1.21452.10" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.3.5" PrivateAssets="all" />
     <PackageReference Include="NodaTime" Version="3.0.5" />


### PR DESCRIPTION
* Update to the official release candidate 1 build for .NET 6.
* Re-enable dependabot updates.
* Re-enable .NET SDK updates.
