### PR TITLE
Refactor UI tests

### DIFF
--- a/tests/TodoApp.Tests/BrowserFixtureOptions.cs
+++ b/tests/TodoApp.Tests/BrowserFixtureOptions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace TodoApp;
+
+public class BrowserFixtureOptions
+{
+    public string BrowserType { get; set; } = Microsoft.Playwright.BrowserType.Chromium;
+
+    public string? BrowserChannel { get; set; }
+
+    public string? TestName { get; set; }
+}

--- a/tests/TodoApp.Tests/UITests.cs
+++ b/tests/TodoApp.Tests/UITests.cs
@@ -21,30 +21,36 @@ public class UITests
 
     private ITestOutputHelper OutputHelper { get; }
 
-    public static IEnumerable<object[]> Browsers()
+    public static IEnumerable<object?[]> Browsers()
     {
-        yield return new[] { BrowserType.Chromium };
-        yield return new[] { BrowserType.Chromium + ":chrome" };
+        yield return new[] { BrowserType.Chromium, null };
+        yield return new[] { BrowserType.Chromium, "chrome" };
 
         if (!OperatingSystem.IsLinux())
         {
-            yield return new[] { BrowserType.Chromium + ":msedge" };
+            yield return new[] { BrowserType.Chromium, "msedge" };
         }
 
-        yield return new[] { BrowserType.Firefox };
+        yield return new[] { BrowserType.Firefox, null };
 
         if (OperatingSystem.IsMacOS())
         {
-            yield return new[] { BrowserType.Webkit };
+            yield return new[] { BrowserType.Webkit, null };
         }
     }
 
     [Theory]
     [MemberData(nameof(Browsers))]
-    public async Task Can_Sign_In_And_Manage_Todo_Items(string browserType)
+    public async Task Can_Sign_In_And_Manage_Todo_Items(string browserType, string? browserChannel)
     {
         // Arrange
-        var browser = new BrowserFixture(OutputHelper);
+        var options = new BrowserFixtureOptions
+        {
+            BrowserType = browserType,
+            BrowserChannel = browserChannel
+        };
+
+        var browser = new BrowserFixture(options, OutputHelper);
         await browser.WithPageAsync(async page =>
         {
             // Load the application
@@ -106,7 +112,6 @@ public class UITests
 
             // Assert
             await app.WaitForSignedOutAsync();
-        },
-        browserType);
+        });
     }
 }


### PR DESCRIPTION
Apply some of the refactoring from https://github.com/martincostello/dotnet-playwright-tests to the test fixture used in the sample.

The BrowserStack support hasn't been added as it doesn't work with a `127.0.0.1` IP address (instead of `localhost`) which the app uses as part of its local TLS testing. Maybe that can be refactored/changed in the future, but leaving as-is for now.

