### PR TITLE
Support BrowserStack Automate

### DIFF
--- a/tests/TodoApp.Tests/BrowserFixture.cs
+++ b/tests/TodoApp.Tests/BrowserFixture.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Playwright;
 
 namespace TodoApp;
@@ -29,56 +31,74 @@ public class BrowserFixture
         [CallerMemberName] string? testName = null)
     {
         string activeTestName = Options.TestName ?? testName!;
+        string? videoUrl = null;
 
         // Start Playright and load the browser of the specified type
         using var playwright = await Playwright.CreateAsync();
-        await using var browser = await CreateBrowserAsync(playwright);
 
-        // Create a new context for the test
-        var options = CreateContextOptions();
-        await using var context = await browser.NewContextAsync(options);
-
-        // Enable generating a trace, if enabled, to use with https://trace.playwright.dev
-        if (Options.CaptureTrace)
+        await using (var browser = await CreateBrowserAsync(playwright, activeTestName))
         {
-            await context.Tracing.StartAsync(new()
+            // Create a new context for the test
+            var options = CreateContextOptions();
+            await using var context = await browser.NewContextAsync(options);
+
+            // Enable generating a trace, if enabled, to use with https://trace.playwright.dev.
+            // Tracing does not currently work if using BrowserStack Automate.
+            // See https://github.com/microsoft/playwright-dotnet/issues/1972.
+            if (Options.CaptureTrace && !Options.UseBrowserStack)
             {
-                Screenshots = true,
-                Snapshots = true,
-                Sources = true,
-                Title = activeTestName
-            });
-        }
-
-        // Create a new page for the test to use
-        var page = await context.NewPageAsync();
-
-        // Redirect the browser logs to the xunit output
-        page.Console += (_, e) => OutputHelper.WriteLine(e.Text);
-        page.PageError += (_, e) => OutputHelper.WriteLine(e);
-
-        try
-        {
-            // Run the test, passing it the page to use
-            await action(page);
-        }
-        catch (Exception)
-        {
-            // Try and capture a screenshot at the point the test failed
-            await TryCaptureScreenshotAsync(page, activeTestName);
-            throw;
-        }
-        finally
-        {
-            if (Options.CaptureTrace)
-            {
-                string traceName = GenerateFileName(activeTestName, ".zip");
-                string path = Path.Combine("traces", traceName);
-
-                await context.Tracing.StopAsync(new() { Path = path });
+                await context.Tracing.StartAsync(new()
+                {
+                    Screenshots = true,
+                    Snapshots = true,
+                    Sources = true,
+                    Title = activeTestName
+                });
             }
 
-            await TryCaptureVideoAsync(page, activeTestName);
+            // Create a new page for the test to use
+            var page = await context.NewPageAsync();
+
+            // Redirect the browser logs to the xunit output
+            page.Console += (_, e) => OutputHelper.WriteLine(e.Text);
+            page.PageError += (_, e) => OutputHelper.WriteLine(e);
+
+            try
+            {
+                // Run the test, passing it the page to use
+                await action(page);
+
+                // Set the BrowserStack test status, if in use
+                await TrySetSessionStatusAsync(page, "passed");
+            }
+            catch (Exception ex)
+            {
+                // Try and capture a screenshot at the point the test failed
+                await TryCaptureScreenshotAsync(page, activeTestName);
+
+                // Set the BrowserStack test status, if in use
+                await TrySetSessionStatusAsync(page, "failed", ex.Message);
+                throw;
+            }
+            finally
+            {
+                if (Options.CaptureTrace && !Options.UseBrowserStack)
+                {
+                    string traceName = GenerateFileName(activeTestName, ".zip");
+                    string path = Path.Combine("traces", traceName);
+
+                    await context.Tracing.StopAsync(new() { Path = path });
+                }
+
+                videoUrl = await TryCaptureVideoAsync(page, activeTestName);
+            }
+        }
+
+        if (videoUrl is not null)
+        {
+            // For BrowserStack Automate we need to fetch and save the video after the browser
+            // is disposed of as we can't get the video while the session is still running.
+            await CaptureBrowserStackVideoAsync(videoUrl, activeTestName);
         }
     }
 
@@ -100,7 +120,7 @@ public class BrowserFixture
         return options;
     }
 
-    private async Task<IBrowser> CreateBrowserAsync(IPlaywright playwright)
+    private async Task<IBrowser> CreateBrowserAsync(IPlaywright playwright, string testName)
     {
         var options = new BrowserTypeLaunchOptions
         {
@@ -116,7 +136,113 @@ public class BrowserFixture
             options.SlowMo = 250;
         }
 
-        return await playwright[Options.BrowserType].LaunchAsync(options);
+        var browserType = playwright[Options.BrowserType];
+
+        if (Options.UseBrowserStack && Options.BrowserStackCredentials != default)
+        {
+            // Allowed browsers are "chrome", "edge", "playwright-chromium", "playwright-firefox" and "playwright-webkit".
+            // See https://www.browserstack.com/docs/automate/playwright and
+            // https://github.com/browserstack/playwright-browserstack/blob/761b35bf79d79ddbfdf518fa6969b409bc42a941/google_search.js
+            string browser;
+
+            if (!string.IsNullOrEmpty(options.Channel))
+            {
+                browser = options.Channel switch
+                {
+                    "msedge" => "edge",
+                    _ => options.Channel,
+                };
+            }
+            else
+            {
+                browser = "playwright-" + Options.BrowserType;
+            }
+
+            // Use the version of the Microsoft.Playwright assembly unless
+            // explicitly overridden by the options specified by the test.
+            string playwrightVersion =
+                Options.PlaywrightVersion ??
+                typeof(IBrowser).Assembly.GetName()!.Version!.ToString(3);
+
+            // Supported capabilities and operating systems are documented at the following URLs:
+            // https://www.browserstack.com/automate/capabilities
+            // https://www.browserstack.com/list-of-browsers-and-platforms/playwright
+            var capabilities = new Dictionary<string, string?>()
+            {
+                ["browser"] = browser,
+                ["browserstack.accessKey"] = Options.BrowserStackCredentials.AccessKey,
+                ["browserstack.username"] = Options.BrowserStackCredentials.UserName,
+                ["build"] = Options.Build ?? GetDefaultBuildNumber(),
+                ["client.playwrightVersion"] = playwrightVersion,
+                ["name"] = testName,
+                ["os"] = Options.OperatingSystem,
+                ["os_version"] = Options.OperatingSystemVersion,
+                ["project"] = Options.ProjectName ?? GetDefaultProject()
+            };
+
+            BrowserStackLocalService? localService = null;
+
+            try
+            {
+                if (Options.UseBrowserStackLocal)
+                {
+                    capabilities["browserstack.local"] = "true";
+                    capabilities["browserstack.localIdentifier"] = Options.BrowserStackLocalOptions?.LocalIdentifier;
+
+                    localService = new BrowserStackLocalService(
+                        Options.BrowserStackCredentials.AccessKey,
+                        Options.BrowserStackLocalOptions);
+
+                    await localService.StartAsync();
+                }
+
+                // Serialize the capabilities as a JSON blob and pass to the
+                // BrowserStack endpoint in the "caps" query string parameter.
+                string json = JsonSerializer.Serialize(capabilities);
+                string wsEndpoint = QueryHelpers.AddQueryString(Options.BrowserStackEndpoint.ToString(), "caps", json);
+
+                var remoteBrowser = await browserType.ConnectAsync(wsEndpoint, new()
+                {
+                    SlowMo = options.SlowMo,
+                    Timeout = options.Timeout
+                });
+
+                // Wrap the IBrowser so we can dispose of the BrowserStack Local
+                // service when the test has completed, if it was in use at all.
+                return new RemoteBrowser(remoteBrowser, localService);
+            }
+            catch (Exception)
+            {
+                localService?.Dispose();
+                throw;
+            }
+        }
+
+        return await browserType.LaunchAsync(options);
+    }
+
+    private static string GetDefaultBuildNumber()
+    {
+        string? build = Environment.GetEnvironmentVariable("GITHUB_RUN_NUMBER");
+
+        if (!string.IsNullOrEmpty(build))
+        {
+            return build;
+        }
+
+        return typeof(BrowserFixture).Assembly.GetName().Version!.ToString(3);
+    }
+
+    private static string GetDefaultProject()
+    {
+        string? project = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+
+        if (!string.IsNullOrEmpty(project))
+        {
+            return project.Split('/')[1];
+        }
+
+        return "TodoApp";
     }
 
     private string GenerateFileName(string testName, string extension)
@@ -160,11 +286,11 @@ public class BrowserFixture
         }
     }
 
-    private async Task TryCaptureVideoAsync(IPage page, string testName)
+    private async Task<string?> TryCaptureVideoAsync(IPage page, string testName)
     {
         if (!Options.CaptureVideo || page.Video is null)
         {
-            return;
+            return null;
         }
 
         try
@@ -172,8 +298,22 @@ public class BrowserFixture
             string fileName = GenerateFileName(testName, ".webm");
             string path = Path.Combine(VideosDirectory, fileName);
 
-            await page.CloseAsync();
-            await page.Video.SaveAsAsync(path);
+            if (Options.UseBrowserStack)
+            {
+                // BrowserStack Automate does not stop the video until the session has ended, so there
+                // is no way to get the video to save it to a file, other than after the browser session
+                // has ended. Instead, we get the URL to the video and then download it afterwards.
+                // See https://www.browserstack.com/docs/automate/playwright/debug-failed-tests#video-recording.
+                string session = await page.EvaluateAsync<string>("_ => {}", "browserstack_executor: {\"action\":\"getSessionDetails\"}");
+
+                using var document = JsonDocument.Parse(session);
+                return document.RootElement.GetProperty("video_url").GetString();
+            }
+            else
+            {
+                await page.CloseAsync();
+                await page.Video.SaveAsAsync(path);
+            }
 
             OutputHelper.WriteLine($"Video saved to {path}.");
         }
@@ -181,5 +321,117 @@ public class BrowserFixture
         {
             OutputHelper.WriteLine("Failed to capture video: " + ex);
         }
+
+        return null;
+    }
+
+    private async Task CaptureBrowserStackVideoAsync(string videoUrl, string testName)
+    {
+        using var client = new HttpClient();
+
+        for (int i = 0; i < 10; i++)
+        {
+            using var response = await client.GetAsync(videoUrl);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // The video may take a few seconds to be available
+                await Task.Delay(TimeSpan.FromSeconds(2));
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+
+            string extension = Path.GetExtension(response.Content.Headers.ContentDisposition?.FileName) ?? ".mp4";
+            string fileName = GenerateFileName(testName, extension);
+            string path = Path.Combine(VideosDirectory, fileName);
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(VideosDirectory);
+            }
+
+            using var file = File.OpenWrite(path);
+
+            using var stream = await response.Content.ReadAsStreamAsync();
+            await stream.CopyToAsync(file);
+
+            OutputHelper.WriteLine($"Video saved to {path}.");
+            break;
+        }
+    }
+
+    private async Task TrySetSessionStatusAsync(IPage page, string status, string reason = "")
+    {
+        if (!Options.UseBrowserStack)
+        {
+            return;
+        }
+
+        // See https://www.browserstack.com/docs/automate/playwright/mark-test-status#mark-the-status-of-your-playwright-test-using-rest-api-duringafter-the-test-script-run
+        string json = JsonSerializer.Serialize(new
+        {
+            action = "setSessionStatus",
+            arguments = new
+            {
+                status,
+                reason
+            }
+        });
+
+        await page.EvaluateAsync("_ => {}", $"browserstack_executor: {json}");
+    }
+
+    private sealed class RemoteBrowser : IBrowser
+    {
+        private readonly IBrowser _browser;
+        private readonly IDisposable? _localService;
+        private bool _disposed;
+
+        internal RemoteBrowser(IBrowser browser, IDisposable? localService)
+        {
+            _browser = browser;
+            _localService = localService;
+        }
+
+        public IReadOnlyList<IBrowserContext> Contexts => _browser.Contexts;
+
+        public bool IsConnected => _browser.IsConnected;
+
+        public string Version => _browser.Version;
+
+        public event EventHandler<IBrowser> Disconnected
+        {
+            add => _browser.Disconnected += value;
+            remove => _browser.Disconnected -= value;
+        }
+
+        public Task CloseAsync() => _browser.CloseAsync();
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _browser.DisposeAsync();
+            }
+            finally
+            {
+                if (!_disposed)
+                {
+                    if (_localService != null)
+                    {
+                        _localService.Dispose();
+                    }
+
+                    _disposed = true;
+                }
+            }
+        }
+
+        public Task<IBrowserContext> NewContextAsync(BrowserNewContextOptions? options = null)
+            => _browser.NewContextAsync(options);
+
+        public Task<IPage> NewPageAsync(BrowserNewPageOptions? options = null)
+            => _browser.NewPageAsync(options);
     }
 }

--- a/tests/TodoApp.Tests/BrowserFixtureOptions.cs
+++ b/tests/TodoApp.Tests/BrowserFixtureOptions.cs
@@ -17,4 +17,24 @@ public class BrowserFixtureOptions
     public bool CaptureVideo { get; set; } = BrowserFixture.IsRunningInGitHubActions;
 
     public string? TestName { get; set; }
+
+    public string? Build { get; set; }
+
+    public string? OperatingSystem { get; set; }
+
+    public string? OperatingSystemVersion { get; set; }
+
+    public string? PlaywrightVersion { get; set; }
+
+    public string? ProjectName { get; set; }
+
+    public bool UseBrowserStack { get; set; }
+
+    public bool UseBrowserStackLocal { get; set; }
+
+    public (string UserName, string AccessKey) BrowserStackCredentials { get; set; }
+
+    public BrowserStackLocalOptions? BrowserStackLocalOptions { get; set; }
+
+    public Uri BrowserStackEndpoint { get; set; } = new("wss://cdp.browserstack.com/playwright", UriKind.Absolute);
 }

--- a/tests/TodoApp.Tests/BrowserStackLocalOptions.cs
+++ b/tests/TodoApp.Tests/BrowserStackLocalOptions.cs
@@ -1,0 +1,62 @@
+﻿namespace TodoApp;
+
+public sealed class BrowserStackLocalOptions
+{
+    //// See https://www.browserstack.com/local-testing/binary-params
+
+    public string? LocalIdentifier { get; set; }
+
+    public string? ProxyHostName { get; set; }
+
+    public string? ProxyPassword { get; set; }
+
+    public int? ProxyPort { get; set; }
+
+    public string? ProxyUserName { get; set; }
+
+    internal static IList<string> BuildCommandLine(string apiKey, BrowserStackLocalOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(apiKey);
+
+        var arguments = new List<string>()
+        {
+            "--key",
+            apiKey,
+            "--only-automate"
+        };
+
+        if (!string.IsNullOrWhiteSpace(options?.LocalIdentifier))
+        {
+            arguments.Add("--local-identifier");
+            arguments.Add(options.LocalIdentifier);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options?.ProxyHostName))
+        {
+            if (!options.ProxyPort.HasValue)
+            {
+                throw new ArgumentException("No proxy port number specified.", nameof(options));
+            }
+
+            arguments.Add("--proxy-host");
+            arguments.Add( options.ProxyHostName);
+            arguments.Add("--proxy-port");
+            arguments.Add(options.ProxyPort.Value.ToString(CultureInfo.InvariantCulture));
+
+            if (!string.IsNullOrWhiteSpace(options.ProxyUserName))
+            {
+                if (string.IsNullOrWhiteSpace(options.ProxyPassword))
+                {
+                    throw new ArgumentException("No proxy password specified.", nameof(options));
+                }
+
+                arguments.Add("--proxy-user");
+                arguments.Add(options.ProxyUserName);
+                arguments.Add("--proxy-pass");
+                arguments.Add(options.ProxyPassword);
+            }
+        }
+
+        return arguments;
+    }
+}

--- a/tests/TodoApp.Tests/BrowserStackLocalService.cs
+++ b/tests/TodoApp.Tests/BrowserStackLocalService.cs
@@ -1,0 +1,314 @@
+﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+
+namespace TodoApp;
+
+internal sealed class BrowserStackLocalService : IDisposable
+{
+    private static readonly SemaphoreSlim _downloadLock = new(1, 1);
+    private static string? _binaryPath;
+
+    private readonly string _accessKey;
+    private readonly BrowserStackLocalOptions? _options;
+
+    private bool _outputRedirected;
+    private Process? _process;
+    private bool _disposed;
+
+    public BrowserStackLocalService(
+        string accessKey,
+        BrowserStackLocalOptions? options)
+    {
+        _accessKey = accessKey;
+        _options = options;
+    }
+
+    ~BrowserStackLocalService()
+    {
+        DisposeInternal();
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        var arguments = BrowserStackLocalOptions.BuildCommandLine(_accessKey, _options);
+
+        // Ensure the binary for the BrowserStack Local proxy service is available
+        if (_binaryPath is null)
+        {
+            // If tests are run in parallel, only download the file once
+            await _downloadLock.WaitAsync(cancellationToken);
+
+            try
+            {
+#pragma warning disable CA1508
+                if (_binaryPath is null)
+#pragma warning restore CA1508
+                {
+                    _binaryPath = await EnsureBinaryAsync(cancellationToken);
+                }
+            }
+            finally
+            {
+                _downloadLock.Release();
+            }
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            CreateNoWindow = true,
+            FileName = _binaryPath,
+            RedirectStandardError = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        _process = Process.Start(startInfo);
+
+        if (_process is null)
+        {
+            throw new InvalidOperationException("Failed to start BrowserStack Local service.");
+        }
+
+        try
+        {
+            var stdout = new StringBuilder();
+            var tcs = new TaskCompletionSource();
+
+            void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
+            {
+                if (e.Data is not null)
+                {
+                    stdout.AppendLine(e.Data);
+
+                    if (e.Data.Contains("Press Ctrl-C to exit", StringComparison.OrdinalIgnoreCase))
+                    {
+                        tcs.SetResult();
+                    }
+                }
+            }
+
+            _process.OutputDataReceived += OnOutputDataReceived;
+            _process.BeginOutputReadLine();
+
+            _outputRedirected = true;
+
+            if (_process.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to start process. The process exited with code {_process.ExitCode}. This could be because {GetBinaryName()} requires updating; an updated version can be downloaded from {GetDownloadUri()}.");
+            }
+
+            // Give the BrowserStackLocal process time to initialize
+            var timeout = TimeSpan.FromSeconds(15);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+
+            try
+            {
+                await tcs.Task.WaitAsync(cts.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                var exception = new InvalidOperationException(
+                    $"Process failed to initialize within {timeout}. This could be because {GetBinaryName()} requires updating; an updated version can be downloaded from {GetDownloadUri()}. Alternatively, it could be caused by a firewall.");
+
+                exception.Data["stdout"] = stdout.ToString();
+
+                throw exception;
+            }
+
+            // Once started, we don't need to listen to stdout any more
+            _process.OutputDataReceived -= OnOutputDataReceived;
+            stdout.Clear();
+        }
+        catch (Exception)
+        {
+            if (_outputRedirected)
+            {
+                _process.CancelOutputRead();
+            }
+
+            if (!_process.HasExited)
+            {
+                try
+                {
+                    _process.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+
+            _process.Dispose();
+            _process = null;
+
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        DisposeInternal();
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task<string> EnsureBinaryAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            string folderPath =
+                OperatingSystem.IsWindows() ?
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) :
+                Path.GetTempPath();
+
+            string localCachePath = Path.Combine(folderPath, "_BrowserStackLocal");
+            string binaryPath = Path.Combine(localCachePath, GetBinaryName());
+
+            string zippedBinaryPath = binaryPath + ".zip";
+            string cachedETagFileName = zippedBinaryPath + ".ETag";
+
+            Uri downloadUri = GetDownloadUri();
+
+            using var client = new HttpClient();
+
+            string currentETag;
+
+            // Get the current ETag of the ZIP file containing the BrowserStack Local binary
+            using (var request = new HttpRequestMessage(HttpMethod.Head, downloadUri))
+            {
+                using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                currentETag = response.Headers.ETag?.Tag ?? string.Empty;
+            }
+
+            // Is the local version of the ZIP file up-to-date?
+            bool needToDownload =
+                !File.Exists(cachedETagFileName) ||
+                !string.Equals(await File.ReadAllTextAsync(cachedETagFileName, Encoding.UTF8, cancellationToken), currentETag, StringComparison.Ordinal);
+
+            if (needToDownload)
+            {
+                // Download the latest ZIP file
+                byte[] zipBytes = await client.GetByteArrayAsync(downloadUri, cancellationToken);
+
+                if (!Directory.Exists(localCachePath))
+                {
+                    Directory.CreateDirectory(localCachePath);
+                }
+
+                await File.WriteAllBytesAsync(zippedBinaryPath, zipBytes, cancellationToken);
+                await File.WriteAllTextAsync(cachedETagFileName, currentETag, Encoding.UTF8, cancellationToken);
+            }
+
+            // Update the binary with the one from the ZIP file
+            if (!File.Exists(binaryPath) || needToDownload)
+            {
+                if (!Directory.Exists(localCachePath))
+                {
+                    Directory.CreateDirectory(localCachePath);
+                }
+                else if (File.Exists(binaryPath))
+                {
+                    File.Delete(binaryPath);
+                }
+
+                ZipFile.ExtractToDirectory(zippedBinaryPath, localCachePath);
+            }
+
+            return binaryPath;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to download BrowserStack Local binary.", ex);
+        }
+    }
+
+    private static string GetBinaryName()
+        => OperatingSystem.IsWindows() ? "BrowserStackLocal.exe" : "BrowserStackLocal";
+
+    private static Uri GetDownloadUri()
+    {
+        string fileName;
+
+        if (OperatingSystem.IsWindows())
+        {
+            fileName = "BrowserStackLocal-win32.zip";
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            fileName = "BrowserStackLocal-darwin-x64.zip";
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            fileName = Environment.Is64BitOperatingSystem ?
+                "BrowserStackLocal-linux-x64.zip" :
+                "BrowserStackLocal-linux-ia32.zip";
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("The current platform is not supported.");
+        }
+
+        return new UriBuilder("https://www.browserstack.com")
+        {
+            Path = "browserstack-local/" + fileName
+        }.Uri;
+    }
+
+    private void DisposeInternal()
+    {
+        if (!_disposed)
+        {
+            if (_process != null)
+            {
+                if (!_process.HasExited)
+                {
+                    try
+                    {
+                        if (_outputRedirected)
+                        {
+                            _process.CancelOutputRead();
+                        }
+
+                        try
+                        {
+                            _process.Kill();
+                        }
+                        catch (InvalidOperationException)
+                        {
+                        }
+
+                        if (_process.WaitForExit(10_000))
+                        {
+                            // It seems to take a second or so to ensure the process
+                            // is stopped so we can delete the extracted binary
+                            Thread.Sleep(TimeSpan.FromSeconds(1));
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                    catch (SystemException)
+                    {
+                    }
+                }
+
+                _process.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
Add support for optional testing with BrowserStack Automate, which incorporates the use of [Local Testing](https://www.browserstack.com/local-testing/automate).
