### PR TITLE
Do not start TestServer

### DIFF
--- a/tests/TodoApp.Tests/HttpServerFixture.cs
+++ b/tests/TodoApp.Tests/HttpServerFixture.cs
@@ -84,7 +84,6 @@ public sealed class HttpServerFixture : TodoAppFixture
         // Otherwise the internals will complain about the host's server
         // not being an instance of the concrete type TestServer.
         // See https://github.com/dotnet/aspnetcore/pull/34702.
-        testHost.Start();
         return testHost;
     }
 


### PR DESCRIPTION
`TestServer` _shouldn't_ need to be used, and according to #866 not doing so should speed things up.
