### PR TITLE
Use token option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,10 @@ jobs:
 
     - uses: codecov/codecov-action@v4
       name: Upload coverage to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./artifacts/coverage.cobertura.xml,./src/TodoApp/coverage/lcov.info
         flags: ${{ matrix.os-name }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use the explicit token option, rather than setting an environment variable.
