### PR TITLE
Update Node.js v24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
-        node-version: '22'
+        node-version: '24'
 
     - name: Build, Test and Publish
       shell: pwsh


### PR DESCRIPTION
Update GitHub Actions workflows to use Node.js v24.
