### PR TITLE
Use CreateTempSubdirectory

### DIFF
--- a/tests/TodoApp.Tests/BrowserStackLocalService.cs
+++ b/tests/TodoApp.Tests/BrowserStackLocalService.cs
@@ -158,7 +158,7 @@ internal sealed class BrowserStackLocalService(
             string folderPath =
                 OperatingSystem.IsWindows() ?
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) :
-                Path.GetTempPath();
+                Directory.CreateTempSubdirectory("_BrowserStackLocal").FullName;
 
             string localCachePath = Path.Combine(folderPath, "_BrowserStackLocal");
             string binaryPath = Path.Combine(localCachePath, GetBinaryName());

--- a/tests/TodoApp.Tests/TodoAppFixture.cs
+++ b/tests/TodoApp.Tests/TodoAppFixture.cs
@@ -46,12 +46,7 @@ public class TodoAppFixture : WebApplicationFactory<Program>, ITestOutputHelperA
         {
             // Configure the test fixture to write the SQLite database
             // to a temporary directory, rather than in App_Data.
-            var dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
-            if (!Directory.Exists(dataDirectory))
-            {
-                Directory.CreateDirectory(dataDirectory);
-            }
+            var dataDirectory = Directory.CreateTempSubdirectory().FullName;
 
             // Also override the default options for the GitHub OAuth provider
             var config = new[]


### PR DESCRIPTION
Replace usage of `Path.GetTempPath` with `Directory.CreateTempSubdirectory()`.
